### PR TITLE
use otel semantic convention attribute name for db query

### DIFF
--- a/hook/trace/hook.go
+++ b/hook/trace/hook.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	sqlQuery = "sql.query"
+	sqlQuery = "db.statement"
 )
 
 type Hook struct {


### PR DESCRIPTION
In OTEL's [semantic convention page](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes), they mention that database queries should be recorded using the attribute `db.statement`.

It would be nice to use it instead of `sql.query`