### PR TITLE
feat(hook): use tx context inside Commit/Rollback after

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -162,9 +162,9 @@ func (c otConn) Begin() (tx driver.Tx, err error) {
 	return wrapTx(ctx, c.connID, tx, c.Options), nil
 }
 
-func (c otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
+func (c otConn) BeginTx(spanCtx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
 	evt := newEvent(c.Options, c.connID, MethodBegin, "", nil)
-	ctx = before(c.Hooks, ctx, evt)
+	ctx := before(c.Hooks, spanCtx, evt)
 	defer func() {
 		evt.Err = err
 		after(c.Hooks, ctx, evt)
@@ -179,7 +179,7 @@ func (c otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.T
 			return nil, err
 		}
 	}
-	return wrapTx(ctx, c.connID, tx, c.Options), nil
+	return wrapTx(spanCtx, c.connID, tx, c.Options), nil
 }
 
 func (c otConn) Close() (err error) {
@@ -534,7 +534,7 @@ type otTx struct {
 
 func (t otTx) Commit() (err error) {
 	evt := newEvent(t.Options, t.connID, MethodCommit, "", nil)
-	ctx := before(t.Hooks, context.Background(), evt)
+	ctx := before(t.Hooks, t.ctx, evt)
 	defer func() {
 		evt.Err = err
 		after(t.Hooks, ctx, evt)
@@ -545,7 +545,7 @@ func (t otTx) Commit() (err error) {
 
 func (t otTx) Rollback() (err error) {
 	evt := newEvent(t.Options, t.connID, MethodRollback, "", nil)
-	ctx := before(t.Hooks, context.Background(), evt)
+	ctx := before(t.Hooks, t.ctx, evt)
 	defer func() {
 		evt.Err = err
 		after(t.Hooks, ctx, evt)


### PR DESCRIPTION
Fixes misplaced commit and rollback spans, which are traced inside own
span all the time.

Fixed version of https://github.com/j2gg0s/otsql/pull/15 - now the spans are correctly placed as `begin`, `query`, `commit`.

![image](https://user-images.githubusercontent.com/8830676/197488919-0a3d17e7-613d-4006-a135-062399ae2315.png)

